### PR TITLE
Populate credentials in requests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.github.nshobayo</groupId>
 	<artifactId>OktaAWSCLI</artifactId>
-	<version>1.0.0</version>
+	<version>1.0.1</version>
 	<dependencies>
 		<dependency>
 			<groupId>org.json</groupId>

--- a/src/main/java/org/github/nshobayo/AssumeRoleWithOktaSAML.java
+++ b/src/main/java/org/github/nshobayo/AssumeRoleWithOktaSAML.java
@@ -84,6 +84,10 @@ public class AssumeRoleWithOktaSAML {
 	
 	private static AWSSecurityTokenServiceClient buildStsClient()
 	{
+		// The SDK requires credentials for all requests, including requests to obtain credentials.
+		// Use fake, meaningless credentials to perform this request to prevent an exception.
+		AWSCredentials blankCredentials = new BasicAWSCredentials("", "");
+
 		AWSSecurityTokenServiceClient stsClient = null;
 		if (proxyHost != null && proxyPort > 0) {
 			ClientConfiguration clientConfig = new ClientConfiguration();
@@ -97,9 +101,9 @@ public class AssumeRoleWithOktaSAML {
 				clientConfig.setProxyDomain(proxyDomain);
 			}
 			
-			stsClient = new AWSSecurityTokenServiceClient(clientConfig);
+			stsClient = new AWSSecurityTokenServiceClient(blankCredentials, clientConfig);
 		} else {
-			stsClient = new AWSSecurityTokenServiceClient();
+			stsClient = new AWSSecurityTokenServiceClient(blankCredentials);
 		}
 		return stsClient;
 	}


### PR DESCRIPTION
The AWS SDK requires all requests to be credentialed, including (oddly) requests to STS to obtain credentials. The credentials are not actually used in this case, but are required to be present by the SDK. This means that an empty credentials file such as the following, which OktaAWSCLI will generate if one does not exist, will throw an exception:
```
[don@zeus AWS-CLI]$ cat ~/.aws/credentials 
[default]
aws_access_key_id=
aws_secret_access_key=
```

The program output is similar to the following:
```
[don@zeus AWS-CLI]$ java -jar target/OktaAWSCLI-1.0.0-jar-with-dependencies.jar 
Username: don-code
Password: 
[ 1 ]: (redacted)

Using given role: (redacted)
Exception in thread "main" com.amazonaws.AmazonClientException: Unable to load AWS credentials from any provider in the chain
	at com.amazonaws.auth.AWSCredentialsProviderChain.getCredentials(AWSCredentialsProviderChain.java:131)
	at com.amazonaws.http.AmazonHttpClient.getCredentialsFromContext(AmazonHttpClient.java:774)
	at com.amazonaws.http.AmazonHttpClient.executeOneRequest(AmazonHttpClient.java:800)
	at com.amazonaws.http.AmazonHttpClient.executeHelper(AmazonHttpClient.java:695)
	at com.amazonaws.http.AmazonHttpClient.doExecute(AmazonHttpClient.java:447)
	at com.amazonaws.http.AmazonHttpClient.executeWithTimer(AmazonHttpClient.java:409)
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:358)
	at com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient.doInvoke(AWSSecurityTokenServiceClient.java:1413)
	at com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient.invoke(AWSSecurityTokenServiceClient.java:1383)
	at com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient.assumeRoleWithSAML(AWSSecurityTokenServiceClient.java:664)
	at org.github.nshobayo.AssumeRoleWithOktaSAML.assumeAWSRole(AssumeRoleWithOktaSAML.java:650)
	at org.github.nshobayo.AssumeRoleWithOktaSAML.main(AssumeRoleWithOktaSAML.java:720)
```

This change ignores the default credentials in ~/.aws/credentials, and passes an empty set of credentials to the SDK to keep it happy.